### PR TITLE
Ebean13 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean</artifactId>
-      <version>12.6.0</version>
+      <version>13.5.0</version>
       <scope>provided</scope>
     </dependency>
 

--- a/src/main/java/io/ebean/MockiEbean.java
+++ b/src/main/java/io/ebean/MockiEbean.java
@@ -198,12 +198,12 @@ public class MockiEbean {
     if (original == null) {
       throw new IllegalStateException("Original EbeanServer instance is null");
     }
-    if (original.getName() == null) {
+    if (original.name() == null) {
       throw new IllegalStateException("Original EbeanServer name is null");
     }
 
     // restore the original EbeanServer back
-    DB.mock(original.getName(), original, true);
+    DB.mock(original.name(), original, true);
   }
 
 }

--- a/src/main/java/io/ebean/mocker/DelegateEbeanServer.java
+++ b/src/main/java/io/ebean/mocker/DelegateEbeanServer.java
@@ -33,6 +33,8 @@ import io.ebean.ValuePair;
 import io.ebean.Version;
 import io.ebean.annotation.Platform;
 import io.ebean.annotation.TxIsolation;
+import io.ebean.bean.BeanLoader;
+import io.ebean.bean.EntityBeanIntercept;
 import io.ebean.mocker.backgroundexecutor.ImmediateBackgroundExecutor;
 import io.ebean.mocker.delegate.DelegateBulkUpdate;
 import io.ebean.mocker.delegate.DelegateFind;
@@ -56,6 +58,7 @@ import io.ebean.event.readaudit.ReadAuditLogger;
 import io.ebean.event.readaudit.ReadAuditPrepare;
 import io.ebean.meta.MetaInfoManager;
 import io.ebean.meta.MetricVisitor;
+import io.ebean.plugin.BeanType;
 import io.ebean.plugin.Property;
 import io.ebean.plugin.SpiServer;
 import io.ebean.text.csv.CsvReader;
@@ -297,15 +300,15 @@ public class DelegateEbeanServer implements SpiEbeanServer, DelegateAwareEbeanSe
   }
 
   @Override
-  public SpiServer getPluginApi() {
-    methodCalls.add(MethodCall.of("getPluginApi"));
-    return delegate.getPluginApi();
+  public SpiServer pluginApi() {
+    methodCalls.add(MethodCall.of("pluginApi"));
+    return delegate.pluginApi();
   }
 
   @Override
-  public AutoTune getAutoTune() {
-    methodCalls.add(MethodCall.of("getAutoTune"));
-    return delegate.getAutoTune();
+  public AutoTune autoTune() {
+    methodCalls.add(MethodCall.of("autoTune"));
+    return delegate.autoTune();
   }
 
   @Override
@@ -315,9 +318,9 @@ public class DelegateEbeanServer implements SpiEbeanServer, DelegateAwareEbeanSe
   }
 
   @Override
-  public Platform getPlatform() {
-    methodCalls.add(MethodCall.of("getPlatform"));
-    return delegate.getPlatform();
+  public Platform platform() {
+    methodCalls.add(MethodCall.of("platform"));
+    return delegate.platform();
   }
 
   @Override
@@ -327,15 +330,15 @@ public class DelegateEbeanServer implements SpiEbeanServer, DelegateAwareEbeanSe
   }
 
   @Override
-  public DataSource getDataSource() {
-    methodCalls.add(MethodCall.of("getDataSource"));
-    return delegate.getDataSource();
+  public DataSource dataSource() {
+    methodCalls.add(MethodCall.of("dataSource"));
+    return delegate.dataSource();
   }
 
   @Override
-  public DataSource getReadOnlyDataSource() {
-    methodCalls.add(MethodCall.of("getReadOnlyDataSource"));
-    return delegate.getReadOnlyDataSource();
+  public DataSource readOnlyDataSource() {
+    methodCalls.add(MethodCall.of("readOnlyDataSource"));
+    return delegate.readOnlyDataSource();
   }
 
   @Override
@@ -381,15 +384,15 @@ public class DelegateEbeanServer implements SpiEbeanServer, DelegateAwareEbeanSe
    * Defaults to use ImmediateBackgroundExecutor, use IgnoreBackgroundExecutor if desired.
    */
   @Override
-  public BackgroundExecutor getBackgroundExecutor() {
-    methodCalls.add(MethodCall.of("getBackgroundExecutor"));
+  public BackgroundExecutor backgroundExecutor() {
+    methodCalls.add(MethodCall.of("backgroundExecutor"));
     return backgroundExecutor;
   }
 
   @Override
-  public ServerCacheManager getServerCacheManager() {
-    methodCalls.add(MethodCall.of("getServerCacheManager"));
-    return delegate.getServerCacheManager();
+  public ServerCacheManager cacheManager() {
+    methodCalls.add(MethodCall.of("cacheManager"));
+    return delegate.cacheManager();
   }
 
   @Override
@@ -405,39 +408,39 @@ public class DelegateEbeanServer implements SpiEbeanServer, DelegateAwareEbeanSe
   }
 
   @Override
-  public String getName() {
-    methodCalls.add(MethodCall.of("getName"));
-    return delegate.getName();
+  public String name() {
+    methodCalls.add(MethodCall.of("name"));
+    return delegate.name();
   }
 
   @Override
-  public ExpressionFactory getExpressionFactory() {
-    methodCalls.add(MethodCall.of("getExpressionFactory"));
-    return delegate.getExpressionFactory();
+  public ExpressionFactory expressionFactory() {
+    methodCalls.add(MethodCall.of("expressionFactory"));
+    return delegate.expressionFactory();
   }
 
   @Override
-  public MetaInfoManager getMetaInfoManager() {
-    methodCalls.add(MethodCall.of("getMetaInfoManager"));
-    return delegate.getMetaInfoManager();
+  public MetaInfoManager metaInfo() {
+    methodCalls.add(MethodCall.of("metaInfo"));
+    return delegate.metaInfo();
   }
 
   @Override
-  public BeanState getBeanState(Object bean) {
-    methodCalls.add(MethodCall.of("getBeanState").with("bean", bean));
-    return delegate.getBeanState(bean);
+  public BeanState beanState(Object bean) {
+    methodCalls.add(MethodCall.of("beanState").with("bean", bean));
+    return delegate.beanState(bean);
   }
 
   @Override
-  public Object getBeanId(Object bean) {
-    methodCalls.add(MethodCall.of("getBeanId").with("bean", bean));
-    return delegate.getBeanId(bean);
+  public Object beanId(Object bean) {
+    methodCalls.add(MethodCall.of("beanId").with("bean", bean));
+    return delegate.beanId(bean);
   }
 
   @Override
-  public Object setBeanId(Object bean, Object id) {
-    methodCalls.add(MethodCall.of("setBeanId").with("bean", bean).with("id", id));
-    return delegate.setBeanId(bean, id);
+  public Object beanId(Object bean, Object id) {
+    methodCalls.add(MethodCall.of("beanId").with("bean", bean).with("id", id));
+    return delegate.beanId(bean, id);
   }
 
   @Override
@@ -483,13 +486,6 @@ public class DelegateEbeanServer implements SpiEbeanServer, DelegateAwareEbeanSe
     methodCalls.add(MethodCall.of("createUpdate").with("beanType", beanType, "ormUpdate", ormUpdate));
     return delegate.createUpdate(beanType, ormUpdate);
   }
-
-  @Override
-  public SqlUpdate createSqlUpdate(String sql) {
-    methodCalls.add(MethodCall.of("createSqlUpdate").with("sql", sql));
-    return delegate.createSqlUpdate(sql);
-  }
-
 
   @Override
   public SqlUpdate sqlUpdate(String sql) {
@@ -598,9 +594,9 @@ public class DelegateEbeanServer implements SpiEbeanServer, DelegateAwareEbeanSe
   // -- delegateQuery ------------------------
 
   @Override
-  public <T> T getReference(Class<T> beanType, Object id) {
-    methodCalls.add(MethodCall.of("getReference").with("beanType", beanType, "id", id));
-    return delegateQuery.getReference(beanType, id);
+  public <T> T reference(Class<T> beanType, Object id) {
+    methodCalls.add(MethodCall.of("reference").with("beanType", beanType, "id", id));
+    return delegateQuery.reference(beanType, id);
   }
 
   @Override
@@ -628,6 +624,11 @@ public class DelegateEbeanServer implements SpiEbeanServer, DelegateAwareEbeanSe
   }
 
   @Override
+  public void lock(Object o) {
+
+  }
+
+  @Override
   public <T> DtoQuery<T> findDto(Class<T> dtoType, String sql) {
     return delegateQuery.findDto(dtoType, sql);
   }
@@ -647,12 +648,6 @@ public class DelegateEbeanServer implements SpiEbeanServer, DelegateAwareEbeanSe
   public <T> Query<T> findNative(Class<T> beanType, String nativeSql) {
     methodCalls.add(MethodCall.of("findNative").with("beanType", beanType).with("nativeSql", nativeSql));
     return delegateQuery.findNative(beanType, nativeSql);
-  }
-
-  @Override
-  public SqlQuery createSqlQuery(String sql) {
-    methodCalls.add(MethodCall.of("createSqlQuery").with("sql", sql));
-    return delegateQuery.createSqlQuery(sql);
   }
 
   @Override
@@ -747,6 +742,12 @@ public class DelegateEbeanServer implements SpiEbeanServer, DelegateAwareEbeanSe
   }
 
   @Override
+  public <T> void findEach(Query<T> query, int i, Consumer<List<T>> consumer, Transaction transaction) {
+    methodCalls.add(MethodCall.of("findEach").with("query", query, "i", i, "consumer", consumer, "transaction", transaction));
+    find.findEach(query, i, consumer, transaction);
+  }
+
+  @Override
   public <T> void findEachWhile(Query<T> query, Predicate<T> consumer, Transaction transaction) {
     methodCalls.add(MethodCall.of("findEachWhile").with("query", query, "consumer", consumer, "transaction", transaction));
     find.findEachWhile(query, consumer, transaction);
@@ -827,7 +828,7 @@ public class DelegateEbeanServer implements SpiEbeanServer, DelegateAwareEbeanSe
   }
 
   @Override
-  public <T> boolean exists(Query<?> query, Transaction transaction) {
+  public <T> boolean exists(Query<T> query, Transaction transaction) {
     methodCalls.add(MethodCall.of("exists").with("query", query, "transaction", transaction));
     return find.exists(query, transaction);
   }
@@ -836,12 +837,6 @@ public class DelegateEbeanServer implements SpiEbeanServer, DelegateAwareEbeanSe
   public <T> Stream<T> findStream(Query<T> query, Transaction transaction) {
     methodCalls.add(MethodCall.of("findStream").with("query", query, "transaction", transaction));
     return find.findStream(query, transaction);
-  }
-
-  @Override
-  public <T> Stream<T> findLargeStream(Query<T> query, Transaction transaction) {
-    methodCalls.add(MethodCall.of("findLargeStream").with("query", query, "transaction", transaction));
-    return find.findLargeStream(query, transaction);
   }
 
   // -- save ------------------------
@@ -1294,6 +1289,11 @@ public class DelegateEbeanServer implements SpiEbeanServer, DelegateAwareEbeanSe
   }
 
   @Override
+  public <T> void findSingleAttributeEach(SpiSqlQuery spiSqlQuery, Class<T> aClass, Consumer<T> consumer) {
+    spiDelegate().findSingleAttributeEach(spiSqlQuery, aClass, consumer);
+  }
+
+  @Override
   public <T> T findOneMapper(SpiSqlQuery query, RowMapper<T> mapper) {
     return spiDelegate().findOneMapper(query, mapper);
   }
@@ -1306,6 +1306,16 @@ public class DelegateEbeanServer implements SpiEbeanServer, DelegateAwareEbeanSe
   @Override
   public void findEachRow(SpiSqlQuery query, RowConsumer consumer) {
     spiDelegate().findEachRow(query, consumer);
+  }
+
+  @Override
+  public <T> QueryIterator<T> findDtoIterate(SpiDtoQuery<T> spiDtoQuery) {
+    return spiDelegate().findDtoIterate(spiDtoQuery);
+  }
+
+  @Override
+  public <T> Stream<T> findDtoStream(SpiDtoQuery<T> spiDtoQuery) {
+    return spiDelegate().findDtoStream(spiDtoQuery);
   }
 
   @Override
@@ -1353,13 +1363,53 @@ public class DelegateEbeanServer implements SpiEbeanServer, DelegateAwareEbeanSe
   }
 
   @Override
-  public DatabaseConfig getServerConfig() {
-    return spiDelegate().getServerConfig();
+  public DatabaseConfig config() {
+    return spiDelegate().config();
   }
 
   @Override
-  public DatabasePlatform getDatabasePlatform() {
-    return spiDelegate().getDatabasePlatform();
+  public DatabasePlatform databasePlatform() {
+    return spiDelegate().databasePlatform();
+  }
+
+  @Override
+  public List<? extends BeanType<?>> beanTypes() {
+    return spiDelegate().beanTypes();
+  }
+
+  @Override
+  public <T> BeanType<T> beanType(Class<T> aClass) {
+    return spiDelegate().beanType(aClass);
+  }
+
+  @Override
+  public List<? extends BeanType<?>> beanTypes(String s) {
+    return spiDelegate().beanTypes(s);
+  }
+
+  @Override
+  public BeanType<?> beanTypeForQueueId(String s) {
+    return spiDelegate().beanTypeForQueueId(s);
+  }
+
+  @Override
+  public BeanLoader beanLoader() {
+    return spiDelegate().beanLoader();
+  }
+
+  @Override
+  public void loadBeanRef(EntityBeanIntercept entityBeanIntercept) {
+    spiDelegate().loadBeanRef(entityBeanIntercept);
+  }
+
+  @Override
+  public void loadBeanL2(EntityBeanIntercept entityBeanIntercept) {
+    spiDelegate().loadBeanL2(entityBeanIntercept);
+  }
+
+  @Override
+  public void loadBean(EntityBeanIntercept entityBeanIntercept) {
+
   }
 
   @Override
@@ -1368,8 +1418,8 @@ public class DelegateEbeanServer implements SpiEbeanServer, DelegateAwareEbeanSe
   }
 
   @Override
-  public PersistenceContextScope getPersistenceContextScope(SpiQuery<?> query) {
-    return spiDelegate().getPersistenceContextScope(query);
+  public PersistenceContextScope persistenceContextScope(SpiQuery<?> query) {
+    return spiDelegate().persistenceContextScope(query);
   }
 
   @Override
@@ -1378,33 +1428,33 @@ public class DelegateEbeanServer implements SpiEbeanServer, DelegateAwareEbeanSe
   }
 
   @Override
-  public SpiTransactionManager getTransactionManager() {
-    return spiDelegate().getTransactionManager();
+  public SpiTransactionManager transactionManager() {
+    return spiDelegate().transactionManager();
   }
 
   @Override
-  public List<BeanDescriptor<?>> getBeanDescriptors() {
-    return spiDelegate().getBeanDescriptors();
+  public List<BeanDescriptor<?>> descriptors() {
+    return spiDelegate().descriptors();
   }
 
   @Override
-  public <T> BeanDescriptor<T> getBeanDescriptor(Class<T> type) {
-    return spiDelegate().getBeanDescriptor(type);
+  public <T> BeanDescriptor<T> descriptor(Class<T> type) {
+    return spiDelegate().descriptor(type);
   }
 
   @Override
-  public BeanDescriptor<?> getBeanDescriptorById(String className) {
-    return spiDelegate().getBeanDescriptorById(className);
+  public BeanDescriptor<?> descriptorById(String className) {
+    return spiDelegate().descriptorById(className);
   }
 
   @Override
-  public BeanDescriptor<?> getBeanDescriptorByQueueId(String queueId) {
-    return spiDelegate().getBeanDescriptorByQueueId(queueId);
+  public BeanDescriptor<?> descriptorByQueueId(String queueId) {
+    return spiDelegate().descriptorByQueueId(queueId);
   }
 
   @Override
-  public List<BeanDescriptor<?>> getBeanDescriptors(String tableName) {
-    return spiDelegate().getBeanDescriptors(tableName);
+  public List<BeanDescriptor<?>> descriptors(String tableName) {
+    return spiDelegate().descriptors(tableName);
   }
 
   @Override
@@ -1428,8 +1478,8 @@ public class DelegateEbeanServer implements SpiEbeanServer, DelegateAwareEbeanSe
   }
 
   @Override
-  public <T> CQuery<T> compileQuery(Query<T> query, Transaction t) {
-    return spiDelegate().compileQuery(query, t);
+  public <T> CQuery<T> compileQuery(SpiQuery.Type type, Query<T> query, Transaction transaction) {
+    return spiDelegate().compileQuery(type, query, transaction);
   }
 
   @Override
@@ -1453,8 +1503,8 @@ public class DelegateEbeanServer implements SpiEbeanServer, DelegateAwareEbeanSe
   }
 
   @Override
-  public int getLazyLoadBatchSize() {
-    return spiDelegate().getLazyLoadBatchSize();
+  public int lazyLoadBatchSize() {
+    return spiDelegate().lazyLoadBatchSize();
   }
 
   @Override
@@ -1463,18 +1513,18 @@ public class DelegateEbeanServer implements SpiEbeanServer, DelegateAwareEbeanSe
   }
 
   @Override
-  public ReadAuditLogger getReadAuditLogger() {
-    return spiDelegate().getReadAuditLogger();
+  public ReadAuditLogger readAuditLogger() {
+    return spiDelegate().readAuditLogger();
   }
 
   @Override
-  public ReadAuditPrepare getReadAuditPrepare() {
-    return spiDelegate().getReadAuditPrepare();
+  public ReadAuditPrepare readAuditPrepare() {
+    return spiDelegate().readAuditPrepare();
   }
 
   @Override
-  public DataTimeZone getDataTimeZone() {
-    return spiDelegate().getDataTimeZone();
+  public DataTimeZone dataTimeZone() {
+    return spiDelegate().dataTimeZone();
   }
 
   @Override
@@ -1505,6 +1555,11 @@ public class DelegateEbeanServer implements SpiEbeanServer, DelegateAwareEbeanSe
   @Override
   public <T> void findDtoEach(SpiDtoQuery<T> query, Consumer<T> consumer) {
     spiDelegate().findDtoEach(query, consumer);
+  }
+
+  @Override
+  public <T> void findDtoEach(SpiDtoQuery<T> spiDtoQuery, int i, Consumer<List<T>> consumer) {
+    spiDelegate().findDtoEach(spiDtoQuery, i, consumer);
   }
 
   @Override

--- a/src/main/java/io/ebean/mocker/DelegateEbeanServer.java
+++ b/src/main/java/io/ebean/mocker/DelegateEbeanServer.java
@@ -653,7 +653,7 @@ public class DelegateEbeanServer implements SpiEbeanServer, DelegateAwareEbeanSe
   @Override
   public SqlQuery sqlQuery(String sql) {
     methodCalls.add(MethodCall.of("sqlQuery").with("sql", sql));
-    return delegateQuery.createSqlQuery(sql);
+    return delegateQuery.sqlQuery(sql);
   }
 
   // -- refresh ------------------------

--- a/src/main/java/io/ebean/mocker/NoopEbeanServer.java
+++ b/src/main/java/io/ebean/mocker/NoopEbeanServer.java
@@ -64,17 +64,17 @@ public class NoopEbeanServer implements Database {
   }
 
   @Override
-  public String getName() {
+  public String name() {
     return name;
   }
 
   @Override
-  public Object getBeanId(Object bean) {
+  public Object beanId(Object bean) {
     return beanId;
   }
 
   @Override
-  public Object setBeanId(Object bean, Object id) {
+  public Object beanId(Object bean, Object id) {
     return beanId;
   }
 
@@ -110,27 +110,27 @@ public class NoopEbeanServer implements Database {
   }
 
   @Override
-  public SpiServer getPluginApi() {
+  public SpiServer pluginApi() {
     return null;
   }
 
   @Override
-  public AutoTune getAutoTune() {
+  public AutoTune autoTune() {
     return null;
   }
 
   @Override
-  public ExpressionFactory getExpressionFactory() {
+  public ExpressionFactory expressionFactory() {
     return Mockito.mock(ExpressionFactory.class);
   }
 
   @Override
-  public MetaInfoManager getMetaInfoManager() {
+  public MetaInfoManager metaInfo() {
     return Mockito.mock(MetaInfoManager.class);
   }
 
   @Override
-  public BeanState getBeanState(Object bean) {
+  public BeanState beanState(Object bean) {
     return Mockito.mock(BeanState.class);
   }
 
@@ -190,12 +190,12 @@ public class NoopEbeanServer implements Database {
   }
 
   @Override
-  public SqlQuery createSqlQuery(String sql) {
+  public SqlQuery sqlQuery(String sql) {
     return Mockito.mock(SqlQuery.class);
   }
 
   @Override
-  public SqlUpdate createSqlUpdate(String sql) {
+  public SqlUpdate sqlUpdate(String sql) {
     return Mockito.mock(SqlUpdate.class);
   }
 
@@ -275,7 +275,7 @@ public class NoopEbeanServer implements Database {
   }
 
   @Override
-  public <T> T getReference(Class<T> beanType, Object id) {
+  public <T> T reference(Class<T> beanType, Object id) {
     return Mockito.mock(beanType);
   }
 
@@ -292,6 +292,11 @@ public class NoopEbeanServer implements Database {
   @Override
   public <T> Set<String> validateQuery(Query<T> query) {
     return Collections.emptySet();
+  }
+
+  @Override
+  public void lock(Object o) {
+
   }
 
   @Override
@@ -560,12 +565,12 @@ public class NoopEbeanServer implements Database {
   }
 
   @Override
-  public ServerCacheManager getServerCacheManager() {
+  public ServerCacheManager cacheManager() {
     return Mockito.mock(ServerCacheManager.class);
   }
 
   @Override
-  public BackgroundExecutor getBackgroundExecutor() {
+  public BackgroundExecutor backgroundExecutor() {
     return Mockito.mock(BackgroundExecutor.class);
   }
 
@@ -580,17 +585,7 @@ public class NoopEbeanServer implements Database {
   }
 
   @Override
-  public Platform getPlatform() {
-    return null;
-  }
-
-  @Override
-  public SqlQuery sqlQuery(String sql) {
-    return null;
-  }
-
-  @Override
-  public SqlUpdate sqlUpdate(String sql) {
+  public Platform platform() {
     return null;
   }
 
@@ -615,12 +610,12 @@ public class NoopEbeanServer implements Database {
   }
 
   @Override
-  public DataSource getDataSource() {
+  public DataSource dataSource() {
     return null;
   }
 
   @Override
-  public DataSource getReadOnlyDataSource() {
+  public DataSource readOnlyDataSource() {
     return null;
   }
 }

--- a/src/main/java/io/ebean/mocker/TDDatabase.java
+++ b/src/main/java/io/ebean/mocker/TDDatabase.java
@@ -65,42 +65,40 @@ public class TDDatabase implements Database {
   }
 
   @Override
-  public SpiServer getPluginApi() {
+  public SpiServer pluginApi() {
     return null;
   }
 
   @Override
-  public AutoTune getAutoTune() {
+  public AutoTune autoTune() { return null; }
+
+  @Override
+  public String name() {
     return null;
   }
 
   @Override
-  public String getName() {
+  public ExpressionFactory expressionFactory() {
     return null;
   }
 
   @Override
-  public ExpressionFactory getExpressionFactory() {
+  public MetaInfoManager metaInfo() {
     return null;
   }
 
   @Override
-  public MetaInfoManager getMetaInfoManager() {
+  public BeanState beanState(Object bean) {
     return null;
   }
 
   @Override
-  public BeanState getBeanState(Object bean) {
+  public Object beanId(Object bean) {
     return null;
   }
 
   @Override
-  public Object getBeanId(Object bean) {
-    return null;
-  }
-
-  @Override
-  public Object setBeanId(Object bean, Object id) {
+  public Object beanId(Object bean, Object id) {
     return id;
   }
 
@@ -161,16 +159,6 @@ public class TDDatabase implements Database {
 
   @Override
   public <T> Update<T> createUpdate(Class<T> beanType, String ormUpdate) {
-    return null;
-  }
-
-  @Override
-  public SqlQuery createSqlQuery(String sql) {
-    return null;
-  }
-
-  @Override
-  public SqlUpdate createSqlUpdate(String sql) {
     return null;
   }
 
@@ -250,7 +238,7 @@ public class TDDatabase implements Database {
   }
 
   @Override
-  public <T> T getReference(Class<T> beanType, Object id) {
+  public <T> T reference(Class<T> beanType, Object id) {
     return null;
   }
 
@@ -258,6 +246,11 @@ public class TDDatabase implements Database {
   @Override
   public <T> Set<String> validateQuery(Query<T> query) {
     return null;
+  }
+
+  @Override
+  public void lock(Object o) {
+
   }
 
   @Override
@@ -550,12 +543,12 @@ public class TDDatabase implements Database {
   }
 
   @Override
-  public ServerCacheManager getServerCacheManager() {
+  public ServerCacheManager cacheManager() {
     return null;
   }
 
   @Override
-  public BackgroundExecutor getBackgroundExecutor() {
+  public BackgroundExecutor backgroundExecutor() {
     return null;
   }
 
@@ -570,7 +563,7 @@ public class TDDatabase implements Database {
   }
 
   @Override
-  public Platform getPlatform() {
+  public Platform platform() {
     return null;
   }
 
@@ -605,12 +598,12 @@ public class TDDatabase implements Database {
   }
 
   @Override
-  public DataSource getDataSource() {
+  public DataSource dataSource() {
     return null;
   }
 
   @Override
-  public DataSource getReadOnlyDataSource() {
+  public DataSource readOnlyDataSource() {
     return null;
   }
 }

--- a/src/main/java/io/ebean/mocker/backgroundexecutor/IgnoreBackgroundExecutor.java
+++ b/src/main/java/io/ebean/mocker/backgroundexecutor/IgnoreBackgroundExecutor.java
@@ -3,6 +3,7 @@ package io.ebean.mocker.backgroundexecutor;
 import io.ebean.BackgroundExecutor;
 
 import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -15,19 +16,21 @@ import java.util.concurrent.TimeUnit;
 public class IgnoreBackgroundExecutor implements BackgroundExecutor {
 
   @Override
+  public <T> Future<T> submit(Callable<T> callable) { return null; }
+
+  @Override
+  public Future<?> submit(Runnable runnable) { return null; }
+
+  @Override
   public void execute(Runnable r) {
     // just ignore
   }
 
   @Override
-  public void executePeriodically(Runnable r, long delay, TimeUnit unit) {
-    // just ignore
-  }
+  public ScheduledFuture<?> scheduleWithFixedDelay(Runnable runnable, long l, long l1, TimeUnit timeUnit) { return null; }
 
   @Override
-  public void executePeriodically(Runnable r, long initialDelay, long delay, TimeUnit unit) {
-    // just ignore
-  }
+  public ScheduledFuture<?> scheduleAtFixedRate(Runnable runnable, long l, long l1, TimeUnit timeUnit) { return null; }
 
   @Override
   public ScheduledFuture<?> schedule(Runnable r, long delay, TimeUnit unit) {

--- a/src/main/java/io/ebean/mocker/backgroundexecutor/ImmediateBackgroundExecutor.java
+++ b/src/main/java/io/ebean/mocker/backgroundexecutor/ImmediateBackgroundExecutor.java
@@ -3,6 +3,7 @@ package io.ebean.mocker.backgroundexecutor;
 import io.ebean.BackgroundExecutor;
 
 import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -15,19 +16,21 @@ import java.util.concurrent.TimeUnit;
 public class ImmediateBackgroundExecutor implements BackgroundExecutor {
 
   @Override
+  public <T> Future<T> submit(Callable<T> callable) { return null; }
+
+  @Override
+  public Future<?> submit(Runnable runnable) { return null; }
+
+  @Override
   public void execute(Runnable r) {
     r.run();
   }
 
   @Override
-  public void executePeriodically(Runnable r, long delay, TimeUnit unit) {
-    r.run();
-  }
+  public ScheduledFuture<?> scheduleWithFixedDelay(Runnable runnable, long l, long l1, TimeUnit timeUnit) { return null; }
 
   @Override
-  public void executePeriodically(Runnable r, long initialDelay, long delay, TimeUnit unit) {
-
-  }
+  public ScheduledFuture<?> scheduleAtFixedRate(Runnable runnable, long l, long l1, TimeUnit timeUnit) { return null; }
 
   @Override
   public ScheduledFuture<?> schedule(Runnable r, long delay, TimeUnit unit) {

--- a/src/main/java/io/ebean/mocker/delegate/DelegateFind.java
+++ b/src/main/java/io/ebean/mocker/delegate/DelegateFind.java
@@ -82,6 +82,11 @@ public class DelegateFind implements InterceptFind {
   }
 
   @Override
+  public <T> void findEach(Query<T> query, int i, Consumer<List<T>> consumer, Transaction transaction) {
+    delegate.extended().findEach(query, i, consumer, transaction);
+  }
+
+  @Override
   public <T> void findEachWhile(Query<T> query, Predicate<T> consumer, Transaction transaction) {
     delegate.extended().findEachWhile(query, consumer, transaction);
   }

--- a/src/main/java/io/ebean/mocker/delegate/DelegateFind.java
+++ b/src/main/java/io/ebean/mocker/delegate/DelegateFind.java
@@ -132,11 +132,6 @@ public class DelegateFind implements InterceptFind {
   }
 
   @Override
-  public <T> Stream<T> findLargeStream(Query<T> query, Transaction transaction) {
-    return delegate.extended().findLargeStream(query, transaction);
-  }
-
-  @Override
   public boolean exists(Query<?> query, Transaction transaction) {
     return delegate.extended().exists(query, transaction);
   }

--- a/src/main/java/io/ebean/mocker/delegate/DelegateQuery.java
+++ b/src/main/java/io/ebean/mocker/delegate/DelegateQuery.java
@@ -52,11 +52,11 @@ public class DelegateQuery {
   }
 
   public SqlQuery createSqlQuery(String sql) {
-    return delegate.createSqlQuery(sql);
+    return delegate.sqlQuery(sql);
   }
 
-  public <T> T getReference(Class<T> beanType, Object id) {
-    return delegate.getReference(beanType, id);
+  public <T> T reference(Class<T> beanType, Object id) {
+    return delegate.reference(beanType, id);
   }
 
   public <T> Set<String> validateQuery(Query<T> query) {

--- a/src/main/java/io/ebean/mocker/delegate/DelegateQuery.java
+++ b/src/main/java/io/ebean/mocker/delegate/DelegateQuery.java
@@ -51,7 +51,7 @@ public class DelegateQuery {
     return delegate.filter(beanType);
   }
 
-  public SqlQuery createSqlQuery(String sql) {
+  public SqlQuery sqlQuery(String sql) {
     return delegate.sqlQuery(sql);
   }
 

--- a/src/main/java/io/ebean/mocker/delegate/InterceptFind.java
+++ b/src/main/java/io/ebean/mocker/delegate/InterceptFind.java
@@ -35,6 +35,8 @@ public interface InterceptFind {
 
   <T> void findEach(Query<T> query, Consumer<T> consumer, Transaction transaction);
 
+  <T> void findEach(Query<T> query, int i, Consumer<List<T>> consumer, Transaction transaction);
+
   <T> void findEachWhile(Query<T> query, Predicate<T> consumer, Transaction transaction);
 
   <T> List<T> findList(Query<T> query, Transaction transaction);
@@ -58,8 +60,6 @@ public interface InterceptFind {
   <T> QueryIterator<T> findIterate(Query<T> query, Transaction transaction);
 
   <T> Stream<T> findStream(Query<T> query, Transaction transaction);
-
-  <T> Stream<T> findLargeStream(Query<T> query, Transaction transaction);
 
   boolean exists(Query<?> query, Transaction transaction);
 }

--- a/src/test/java/io/ebean/mocker/MockiEbeanTest.java
+++ b/src/test/java/io/ebean/mocker/MockiEbeanTest.java
@@ -19,10 +19,10 @@ public class MockiEbeanTest {
     // Setup
     final Long magicBeanId = Long.valueOf(47L);
     Database mock = Mockito.mock(Database.class);
-    when(mock.getBeanId(null)).thenReturn(magicBeanId);
+    when(mock.beanId(null)).thenReturn(magicBeanId);
 
     MockiEbean.runWithMock(mock, () -> {
-      Object value = DB.getBeanId(null);
+      Object value = DB.beanId(null);
       assertEquals(value, magicBeanId);
     });
 
@@ -37,11 +37,11 @@ public class MockiEbeanTest {
     // Setup with Mockito
     final Long magicBeanId = Long.valueOf(47L);
     Database mock = Mockito.mock(Database.class);
-    when(mock.getBeanId(null)).thenReturn(magicBeanId);
+    when(mock.beanId(null)).thenReturn(magicBeanId);
 
     try {
       MockiEbean.runWithMock(mock, (Runnable) () -> {
-        Object value = DB.getBeanId(null);
+        Object value = DB.beanId(null);
         assertEquals(value, magicBeanId);
         throw new IllegalStateException();
       });
@@ -60,7 +60,7 @@ public class MockiEbeanTest {
 
     long result =
       MockiEbean.runWithMock(new TDMockServer(), () -> {
-        Object value = DB.getBeanId(new Object());
+        Object value = DB.beanId(new Object());
         assertEquals(107L, value);
         return 142L;
       });
@@ -80,7 +80,7 @@ public class MockiEbeanTest {
     try {
       long result =
         MockiEbean.runWithMock(new TDMockServer(), () -> {
-          Object value = DB.getBeanId(new Object());
+          Object value = DB.beanId(new Object());
 
           assertEquals(107L, value);
           throw new IllegalStateException();


### PR DESCRIPTION
Hello @rbygrave,

I made some changes to support ebean 13.
There is one last compile error in the project: `DelegateOrmQuery` is a subclass of `DefaultOrmQuery`, but this was changed to be final in https://github.com/ebean-orm/ebean/commit/4109fab0d86ef1ab1b2d5af3b97573a5a02e068f .
How should I fix this problem?

Kind regards
Noemi
